### PR TITLE
run localstack with docker container, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,59 +2,38 @@
 
 ## Prerequisites
 
-* Python (I'm using 3.6.6)
-* Pycharm/some IDE
+* Python 3+
 
 Install the required pip packages for the project with:
 
-`$ pip3 install -r requirements.txt`
+    $ pip3 install -r requirements.txt
 
-## How to run Localstack
+## Run Localstack
 
-When run as a service, Localstack sometimes has issues with where it puts its temporary folders,
-I like to create a directory locally which I know it will be OK with. Run the following in the root of
-the project:
+The easy way is to run localstack with docker-compose
 
-`$ mkdir localstacktmp`
+update `SERVICES` in [docker-compose.yaml](docker-compose.yaml)
 
-To run only the services you require for 'basic' Lambda development, Localstack provides a shorthand 
-option to minimise what you spin up.
-
-`$ env SERVICES=serverless TMPDIR=./localstacktmp localstack start`
-
-You should see the following after a few seconds:
-
+Run localstack container in background.
 ```
-$ env SERVICES=serverless TMPDIR=./localstacktmp localstack start
-Starting local dev environment. CTRL-C to quit.
-Starting mock S3 (http port 4572)...
-Starting mock SNS (http port 4575)...
-Starting mock IAM (http port 4593)...
-Starting mock API Gateway (http port 4567)...
-Starting mock DynamoDB (http port 4569)...
-Starting mock Lambda service (http port 4574)...
-Starting mock CloudWatch Logs (http port 4586)...
-Ready.
+$ docker-compose up -d
 ```
 
-## How to run tests
+## Run tests
 
 A simple test that creates, invokes, and then tears down a simple Lambda is provided.
-
-As your terminal will be taken up by the Localstack service running, either open a new terminal window or 
-create a new pane in your favourite multiplexer of choice!
 
 To run the test, use the following commands within the root of the project:
 
 ```
-$ cd lambda
+$ cd lambda/basic_lambda
 $ pytest -s . 
 ```
 
-You should see similar to the following:
+Wait a while, you should see similar to the following:
 
 ```
-== test session starts ==
+========================================================= test session starts ==========================================================
 platform darwin -- Python 3.6.6, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
 rootdir: /Users/ciaran/dev/localstack_and_pytest_1/lambda
 collected 1 item                                                                                                                                                                               
@@ -65,11 +44,13 @@ Setting up the class
 Tearing down the class
 
 
-== 1 passed in 0.29 seconds ==
+====================================================== 1 passed in 78.43 seconds =======================================================
 ```
 
 If you refer to your terminal window with Localstack running you'll also see:
 
-`2019-07-26T11:10:36:INFO:root: I've been called!`
+```
+2019-07-26T11:10:36:INFO:root: I've been called!
+```
 
 Congrats! You've run your first test against Localstack!

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+
+version: '3'
+
+services:
+  localstack:
+    image: localstack/localstack
+    container_name: localstack
+    ports:
+      - "4567-4599:4567-4599"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=serverless,kms
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+


### PR DESCRIPTION
* Provide `docker-compose.yaml`  
* update the instruction to run localstack in containers, better than install it. 
* fix the path in README to run the test in lambda/basic_lambda/

By the way, how to check the log
```
If you refer to your terminal window with Localstack running you'll also see:

2019-07-26T11:10:36:INFO:root: I've been called!
```

Not sure how to check it. If I check the localstack container logs, I don't see above log, any hits for me?